### PR TITLE
Install Aldryn Essentials

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,4 +20,16 @@ EXPOSE 80
 
 WORKDIR /cms
 RUN /cms/create-users
+ADD settings.py /cms/preview/settings.py
+ADD template.html /cms/preview/templates/aldryn_faq/plugins/category_list.html
+ADD template.html /cms/preview/templates/aldryn_faq/plugins/latest_questions.html
+ADD template.html /cms/preview/templates/aldryn_faq/plugins/question_list.html
+ADD template.html /cms/preview/templates/aldryn_faq/plugins/top_questions.html
+ADD template.html /cms/preview/templates/aldryn_faq/plugins/most_read_questions.html
+ADD template.html /cms/preview/templates/aldryn_jobs/plugins/categories_list.html
+ADD template.html /cms/preview/templates/aldryn_jobs/plugins/latest_entries.html
+ADD template.html /cms/preview/templates/aldryn_people/plugins/standard/people_list.html
+
+RUN python manage.py syncdb --noinput
+RUN python manage.py migrate
 CMD python manage.py runserver 0.0.0.0:80

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,3 +21,10 @@ Pillow>=2.3
 django-sekizai>=0.7
 django-filer
 cmsplugin-filer
+aldryn-newsblog
+aldryn-faq
+aldryn-jobs
+aldryn-people
+aldryn-boilerplates
+aldryn-categories
+django-taggit

--- a/settings.py
+++ b/settings.py
@@ -1,0 +1,224 @@
+import os
+gettext = lambda s: s
+DATA_DIR = os.path.dirname(os.path.dirname(__file__))
+"""
+Django settings for preview project.
+
+For more information on this file, see
+https://docs.djangoproject.com/en/1.7/topics/settings/
+
+For the full list of settings and their values, see
+https://docs.djangoproject.com/en/1.7/ref/settings/
+"""
+
+# Build paths inside the project like this: os.path.join(BASE_DIR, ...)
+import os
+BASE_DIR = os.path.dirname(os.path.dirname(__file__))
+
+
+# Quick-start development settings - unsuitable for production
+# See https://docs.djangoproject.com/en/1.7/howto/deployment/checklist/
+
+# SECURITY WARNING: keep the secret key used in production secret!
+SECRET_KEY = '=3x!$%2s_5jht5=i-j#9-bfpcup0sn*2&_nelyoql&+0p5itgs'
+
+# SECURITY WARNING: don't run with debug turned on in production!
+DEBUG = True
+
+TEMPLATE_DEBUG = True
+
+ALLOWED_HOSTS = []
+
+
+# Application definition
+
+
+
+
+
+ROOT_URLCONF = 'preview.urls'
+
+WSGI_APPLICATION = 'preview.wsgi.application'
+
+
+# Database
+# https://docs.djangoproject.com/en/1.7/ref/settings/#databases
+
+
+
+# Internationalization
+# https://docs.djangoproject.com/en/1.7/topics/i18n/
+
+LANGUAGE_CODE = 'en'
+
+TIME_ZONE = 'Etc/UTC'
+
+USE_I18N = True
+
+USE_L10N = True
+
+USE_TZ = True
+
+
+# Static files (CSS, JavaScript, Images)
+# https://docs.djangoproject.com/en/1.7/howto/static-files/
+
+STATIC_URL = '/static/'
+MEDIA_URL = '/media/'
+MEDIA_ROOT = os.path.join(DATA_DIR, 'media')
+STATIC_ROOT = os.path.join(DATA_DIR, 'static')
+
+STATICFILES_DIRS = (
+    os.path.join(BASE_DIR, 'preview', 'static'),
+)
+SITE_ID = 1
+
+STATICFILES_FINDERS = [
+    'django.contrib.staticfiles.finders.FileSystemFinder',
+    'aldryn_boilerplates.staticfile_finders.AppDirectoriesFinder',
+    'django.contrib.staticfiles.finders.AppDirectoriesFinder',
+]
+
+TEMPLATE_LOADERS = (
+    'django.template.loaders.filesystem.Loader',
+    'django.template.loaders.app_directories.Loader',
+    'django.template.loaders.eggs.Loader'
+)
+
+TEMPLATE_CONTEXT_PROCESSORS = (
+    'django.contrib.auth.context_processors.auth',
+    'django.contrib.messages.context_processors.messages',
+    'django.core.context_processors.i18n',
+    'django.core.context_processors.debug',
+    'django.core.context_processors.request',
+    'django.core.context_processors.media',
+    'django.core.context_processors.csrf',
+    'django.core.context_processors.tz',
+    'sekizai.context_processors.sekizai',
+    'django.core.context_processors.static',
+    'cms.context_processors.cms_settings'
+)
+
+TEMPLATE_DIRS = (
+    os.path.join(BASE_DIR, 'preview', 'templates'),
+)
+
+MIDDLEWARE_CLASSES = (
+    'django.contrib.sessions.middleware.SessionMiddleware',
+    'django.middleware.csrf.CsrfViewMiddleware',
+    'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'django.contrib.messages.middleware.MessageMiddleware',
+    'django.middleware.locale.LocaleMiddleware',
+    'django.middleware.common.CommonMiddleware',
+    'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    'cms.middleware.user.CurrentUserMiddleware',
+    'cms.middleware.page.CurrentPageMiddleware',
+    'cms.middleware.toolbar.ToolbarMiddleware',
+    'cms.middleware.language.LanguageCookieMiddleware'
+)
+
+INSTALLED_APPS = (
+    'djangocms_admin_style',
+    'djangocms_text_ckeditor',
+    'django.contrib.auth',
+    'django.contrib.contenttypes',
+    'django.contrib.sessions',
+    'django.contrib.admin',
+    'django.contrib.sites',
+    'django.contrib.sitemaps',
+    'django.contrib.staticfiles',
+    'django.contrib.messages',
+    'cms',
+    'menus',
+    'sekizai',
+    'treebeard',
+    'djangocms_style',
+    'djangocms_column',
+    'filer',
+    'easy_thumbnails',
+    'cmsplugin_filer_image',
+    'cmsplugin_filer_file',
+    'cmsplugin_filer_folder',
+    'cmsplugin_filer_teaser',
+    'cmsplugin_filer_utils',
+    'cmsplugin_filer_video',
+    'djangocms_flash',
+    'djangocms_googlemap',
+    'djangocms_inherit',
+    'djangocms_link',
+    'reversion',
+    'taggit',
+    'aldryn_categories',
+    'aldryn_newsblog',
+    'aldryn_faq',
+    'aldryn_jobs',
+    'aldryn_people',
+    'aldryn_boilerplates',
+    'preview'
+)
+
+LANGUAGES = (
+    ## Customize this
+    ('en', gettext('en')),
+)
+
+CMS_LANGUAGES = {
+    ## Customize this
+    'default': {
+        'public': True,
+        'hide_untranslated': False,
+        'redirect_on_fallback': True,
+    },
+    1: [
+        {
+            'public': True,
+            'code': 'en',
+            'hide_untranslated': False,
+            'name': gettext('en'),
+            'redirect_on_fallback': True,
+        },
+    ],
+}
+
+CMS_TEMPLATES = (
+    ## Customize this
+    ('fullwidth.html', 'Fullwidth'),
+    ('sidebar_left.html', 'Sidebar Left'),
+    ('sidebar_right.html', 'Sidebar Right')
+)
+
+CMS_PERMISSION = True
+
+CMS_PLACEHOLDER_CONF = {}
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.sqlite3',
+        'HOST': 'localhost',
+        'NAME': 'project.db',
+        'PASSWORD': '',
+        'PORT': '',
+        'USER': ''
+    }
+}
+
+MIGRATION_MODULES = {
+    'cmsplugin_filer_image': 'cmsplugin_filer_image.migrations_django',
+    'cmsplugin_filer_file': 'cmsplugin_filer_file.migrations_django',
+    'cmsplugin_filer_teaser': 'cmsplugin_filer_teaser.migrations_django',
+    'djangocms_inherit': 'djangocms_inherit.migrations_django',
+    'djangocms_column': 'djangocms_column.migrations_django',
+    'djangocms_googlemap': 'djangocms_googlemap.migrations_django',
+    'cmsplugin_filer_folder': 'cmsplugin_filer_folder.migrations_django',
+    'djangocms_flash': 'djangocms_flash.migrations_django',
+    'djangocms_style': 'djangocms_style.migrations_django',
+    'djangocms_link': 'djangocms_link.migrations_django',
+    'cmsplugin_filer_video': 'cmsplugin_filer_video.migrations_django'
+}
+
+THUMBNAIL_PROCESSORS = (
+    'easy_thumbnails.processors.colorspace',
+    'easy_thumbnails.processors.autocrop',
+    'filer.thumbnail_processors.scale_and_crop_with_subject_location',
+    'easy_thumbnails.processors.filters'
+)

--- a/settings.py
+++ b/settings.py
@@ -82,7 +82,7 @@ STATICFILES_FINDERS = [
 TEMPLATE_LOADERS = (
     'django.template.loaders.filesystem.Loader',
     'django.template.loaders.app_directories.Loader',
-    'django.template.loaders.eggs.Loader'
+    'django.template.loaders.eggs.Loader',
 )
 
 TEMPLATE_CONTEXT_PROCESSORS = (
@@ -96,7 +96,7 @@ TEMPLATE_CONTEXT_PROCESSORS = (
     'django.core.context_processors.tz',
     'sekizai.context_processors.sekizai',
     'django.core.context_processors.static',
-    'cms.context_processors.cms_settings'
+    'cms.context_processors.cms_settings',
 )
 
 TEMPLATE_DIRS = (
@@ -114,7 +114,7 @@ MIDDLEWARE_CLASSES = (
     'cms.middleware.user.CurrentUserMiddleware',
     'cms.middleware.page.CurrentPageMiddleware',
     'cms.middleware.toolbar.ToolbarMiddleware',
-    'cms.middleware.language.LanguageCookieMiddleware'
+    'cms.middleware.language.LanguageCookieMiddleware',
 )
 
 INSTALLED_APPS = (
@@ -154,7 +154,7 @@ INSTALLED_APPS = (
     'aldryn_jobs',
     'aldryn_people',
     'aldryn_boilerplates',
-    'preview'
+    'preview',
 )
 
 LANGUAGES = (
@@ -184,7 +184,7 @@ CMS_TEMPLATES = (
     ## Customize this
     ('fullwidth.html', 'Fullwidth'),
     ('sidebar_left.html', 'Sidebar Left'),
-    ('sidebar_right.html', 'Sidebar Right')
+    ('sidebar_right.html', 'Sidebar Right'),
 )
 
 CMS_PERMISSION = True
@@ -198,7 +198,7 @@ DATABASES = {
         'NAME': 'project.db',
         'PASSWORD': '',
         'PORT': '',
-        'USER': ''
+        'USER': '',
     }
 }
 
@@ -213,12 +213,12 @@ MIGRATION_MODULES = {
     'djangocms_flash': 'djangocms_flash.migrations_django',
     'djangocms_style': 'djangocms_style.migrations_django',
     'djangocms_link': 'djangocms_link.migrations_django',
-    'cmsplugin_filer_video': 'cmsplugin_filer_video.migrations_django'
+    'cmsplugin_filer_video': 'cmsplugin_filer_video.migrations_django',
 }
 
 THUMBNAIL_PROCESSORS = (
     'easy_thumbnails.processors.colorspace',
     'easy_thumbnails.processors.autocrop',
     'filer.thumbnail_processors.scale_and_crop_with_subject_location',
-    'easy_thumbnails.processors.filters'
+    'easy_thumbnails.processors.filters',
 )

--- a/template.html
+++ b/template.html
@@ -1,0 +1,4 @@
+<html>
+<head><title></title></head>
+<body></body>
+</html>


### PR DESCRIPTION
Install Aldryn Essentials with the preview CMS.

Note that settings.py is just the standard file generated by djangocms-installer with the essential addons added.

I've included a dummy template just to satisfy the requirement. In a future iteration we might want to convert it to the standard bootstrap template or something more useful.
