### PR TITLE
Viewport metatag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ ADD template.html /cms/preview/templates/aldryn_faq/plugins/most_read_questions.
 ADD template.html /cms/preview/templates/aldryn_jobs/plugins/categories_list.html
 ADD template.html /cms/preview/templates/aldryn_jobs/plugins/latest_entries.html
 ADD template.html /cms/preview/templates/aldryn_people/plugins/standard/people_list.html
+ADD base.html /cms/preview/templates/base.html
 
 RUN python manage.py syncdb --noinput
 RUN python manage.py migrate

--- a/base.html
+++ b/base.html
@@ -1,0 +1,41 @@
+{% load cms_tags menu_tags sekizai_tags %}
+<!doctype html>
+<html>
+    <head>
+        <title>{% block title %}This is my new project home page{% endblock title %}</title>
+        <meta name="viewport" content="width=device-width,initial-scale=1">
+        <style type="text/css">
+            .nav {
+                padding-left: 0;
+            }
+            .nav li {
+                display: inline;
+                list-style-type: none;
+                padding-right: 20px;
+            }
+            .container {
+                width: 940px;
+                margin: 0 auto
+            }
+            .content {
+                float: left;
+                width: 80%;
+            }
+            .sidebar {
+                float: left;
+                width: 20%;
+            }
+        </style>
+        {% render_block "css" %}
+    </head>
+    <body>
+        {% cms_toolbar %}
+        <div class="container">
+            <ul class="nav">
+                {% show_menu 0 100 100 100 %}
+            </ul>
+            {% block content %}{% endblock content %}
+        </div>
+        {% render_block "js" %}
+    </body>
+</html>


### PR DESCRIPTION
In order for the site to work properly on mobile devices:

`<meta name="viewport" content="width=device-width,initial-scale=1">` is required. This will be part of the installer in the future:

https://github.com/nephila/djangocms-installer/pull/211
