### PR TITLE
Remove template loader "eggs.Loader"

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -101,7 +101,6 @@ TEMPLATES = [
                 'aldryn_boilerplates.context_processors.boilerplate',
             ],
             'loaders': [
-                'django.template.loaders.eggs.Loader',
                 'django.template.loaders.filesystem.Loader',
                 'aldryn_boilerplates.template_loaders.AppDirectoriesLoader',
                 'django.template.loaders.app_directories.Loader',


### PR DESCRIPTION
It is deprecated, not needed for this setup and causes fatal errors
in combination with Parler admin templates.

Here is a traceback, just for the record: https://gist.github.com/mikek/1825132f2ac6d08d7eec
